### PR TITLE
Performance optimization in IOUtils.readAll()

### DIFF
--- a/src/main/java/net/dongliu/vcdiff/utils/IOUtils.java
+++ b/src/main/java/net/dongliu/vcdiff/utils/IOUtils.java
@@ -222,7 +222,7 @@ public class IOUtils {
     }
 
     public static byte[] readAll(InputStream in) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream(in.available());
         byte[] buffer = new byte[1024 * 4];
         int n;
         while ((n = in.read(buffer)) != -1) {

--- a/src/test/java/net/dongliu/vcdiff/EncoderDecoderTest.java
+++ b/src/test/java/net/dongliu/vcdiff/EncoderDecoderTest.java
@@ -1,0 +1,169 @@
+package net.dongliu.vcdiff;
+
+import net.dongliu.vcdiff.exception.VcdiffDecodeException;
+import net.dongliu.vcdiff.exception.VcdiffEncodeException;
+import net.dongliu.vcdiff.io.FixedByteArrayStream;
+import net.dongliu.vcdiff.io.RandomAccessStream;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class EncoderDecoderTest {
+    /**
+     * Diff two byte arrays.
+     *
+     * @param source source byte array
+     * @param target modified source array
+     * @return diff
+     * @throws IOException           if something fails
+     * @throws VcdiffEncodeException if something fails
+     */
+    private byte[] diff(byte[] source, byte[] target) throws IOException, VcdiffEncodeException {
+        try (ByteArrayInputStream sourceStream = new ByteArrayInputStream(source);
+             ByteArrayInputStream targetStream = new ByteArrayInputStream(target);
+             ByteArrayOutputStream diffStream = new ByteArrayOutputStream()) {
+
+            new VcdiffEncoder(sourceStream, targetStream, diffStream).encode();
+            return diffStream.toByteArray();
+        }
+    }
+
+    /**
+     * Apply patch to the byte array.
+     *
+     * @param source             source byte array
+     * @param patch              patch to be applied
+     * @param expectedResultSize expected size of the result
+     * @return patched source
+     * @throws IOException           if something fails
+     * @throws VcdiffDecodeException if something fails
+     */
+    private byte[] applyPatch(byte[] source, byte[] patch, int expectedResultSize)
+            throws IOException, VcdiffDecodeException {
+        ByteBuffer outputBuffer = ByteBuffer.allocate(expectedResultSize);
+
+        try (RandomAccessStream sourceStream = new FixedByteArrayStream(source, true);
+             ByteArrayInputStream patchStream = new ByteArrayInputStream(patch);
+             RandomAccessStream targetStream = new FixedByteArrayStream(outputBuffer)) {
+
+            VcdiffDecoder.decode(sourceStream, patchStream, targetStream);
+
+            outputBuffer.rewind();
+            byte[] result = new byte[outputBuffer.remaining()];
+            outputBuffer.get(result);
+            return result;
+        }
+    }
+
+    /**
+     * Fill random data.
+     *
+     * @param array array to be initialized
+     * @return source array
+     */
+    private byte[] fill(byte[] array) {
+        new Random().nextBytes(array);
+        return array;
+    }
+
+    /**
+     * Modify array with random data.
+     *
+     * @param array        array to modify
+     * @param blocks       number of blocks to be modified
+     * @param maxBlockSize maximal number of bytes in each block to modify
+     * @return source array
+     */
+    private byte[] modify(byte[] array, int blocks, int maxBlockSize) {
+        Random random = new Random();
+
+        for (int i = 0; i < blocks; ++i) {
+            int bytes = random.nextInt(maxBlockSize);
+            int blockPtr = random.nextInt(array.length - bytes);
+
+            for (int j = 0; j < bytes; ++j) {
+                array[blockPtr + j] = (byte) random.nextInt(256);
+            }
+        }
+
+        return array;
+    }
+
+    @Test
+    public void testEncodeDecode_RealWordTest() throws Exception {
+        byte[] source = fill(new byte[10 * 1024 * 1024]);
+        byte[] target = modify(Arrays.copyOf(source, source.length), 100, 1000);
+        byte[] patch = diff(source, target);
+        byte[] patchedSource = applyPatch(source, patch, target.length);
+
+        assertArrayEquals(target, patchedSource);
+    }
+
+    @Test
+    public void testEncodeDecode_SameSourceAndTarget() throws Exception {
+        byte[] source = fill(new byte[10 * 1024 * 1024]);
+        byte[] patch = diff(source, source);
+        byte[] patchedSource = applyPatch(source, patch, source.length);
+
+        assertArrayEquals(source, patchedSource);
+    }
+
+    @Test
+    public void testEncodeDecode_EmptySourceAndTarget() throws Exception {
+        byte[] source = {};
+        byte[] target = {};
+        byte[] patch = diff(source, target);
+        byte[] patchedSource = applyPatch(source, patch, target.length);
+
+        assertArrayEquals(target, patchedSource);
+    }
+
+    @Test
+    public void testEncodeDecode_EmptySource() throws Exception {
+        byte[] source = {};
+        byte[] target = fill(new byte[10 * 1024 * 1024]);
+        byte[] patch = diff(source, target);
+        byte[] patchedSource = applyPatch(source, patch, target.length);
+
+        assertArrayEquals(target, patchedSource);
+    }
+
+    @Test
+    public void testEncodeDecode_EmptyTarget() throws Exception {
+        byte[] source = fill(new byte[10 * 1024 * 1024]);
+        byte[] target = {};
+        byte[] patch = diff(source, target);
+        byte[] patchedSource = applyPatch(source, patch, target.length);
+
+        assertArrayEquals(target, patchedSource);
+    }
+
+    @Test
+    public void testEncodeDecode_FirstByteChanged() throws Exception {
+        byte[] source = fill(new byte[10 * 1024 * 1024]);
+        byte[] target = Arrays.copyOf(source, source.length);
+        ++target[0];
+        byte[] patch = diff(source, target);
+        byte[] patchedSource = applyPatch(source, patch, target.length);
+
+        assertArrayEquals(target, patchedSource);
+    }
+
+    @Test
+    public void testEncodeDecode_LastByteChanged() throws Exception {
+        byte[] source = fill(new byte[10 * 1024 * 1024]);
+        byte[] target = Arrays.copyOf(source, source.length);
+        ++target[target.length - 1];
+        byte[] patch = diff(source, target);
+        byte[] patchedSource = applyPatch(source, patch, target.length);
+
+        assertArrayEquals(target, patchedSource);
+    }
+}

--- a/src/test/java/net/dongliu/vcdiff/utils/IOUtilsTest.java
+++ b/src/test/java/net/dongliu/vcdiff/utils/IOUtilsTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Random;
 
 /**
  * @author dongliu
@@ -41,5 +42,26 @@ public class IOUtilsTest {
         j = IOUtils.readVarIntBE(in);
         in.close();
         Assert.assertEquals(i, j);
+    }
+
+    @Test
+    public void testReadAll_ShortData() throws Exception {
+        byte[] expected = {0x00, 0x01, 0x02, 0x03, 0x04};
+
+        try(ByteArrayInputStream stream = new ByteArrayInputStream(expected)) {
+            byte[] actual = IOUtils.readAll(stream);
+            Assert.assertArrayEquals(actual, expected);
+        }
+    }
+
+    @Test
+    public void testReadAll_LongData() throws Exception {
+        byte[] expected = new byte[1024 * 1024];
+        new Random().nextBytes(expected);
+
+        try(ByteArrayInputStream stream = new ByteArrayInputStream(expected)) {
+            byte[] actual = IOUtils.readAll(stream);
+            Assert.assertArrayEquals(actual, expected);
+        }
     }
 }


### PR DESCRIPTION
- All required memory is allocated only once at the beginning (if stream.available() returns total number of bytes in the stream).
- No memory reallocation should occur, GC is not stressed so much.
- No copying of data from old buffer to new larger buffer should occur.